### PR TITLE
修正windows下的文件路径

### DIFF
--- a/app.js
+++ b/app.js
@@ -52,6 +52,10 @@ var main = function(options) {
         });
         requires.push(file.history[0]);
 
+        requires = requires.map(function(c) {
+            return c.split(Path.sep).join('/');
+        });
+
         if (litheOptions.publicdeps) {
             litheOptions.publicdeps.forEach(function(pd) {
                 requires.forEach(function(rd) {


### PR DESCRIPTION
windows下文件路径是反斜杠，修正为斜杠，用来和lithe中定义的mod匹配
